### PR TITLE
Add failing unit test that shows that references are followed even th…

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "through2": "~0.6.3"
   },
   "scripts": {
-    "test": "./node_modules/gulp/bin/gulp.js test-coverage",
-    "dist": "./node_modules/gulp/bin/gulp.js dist"
+    "test": "node node_modules/gulp/bin/gulp.js test-coverage",
+    "dist": "node node_modules/gulp/bin/gulp.js dist"
   },
   "repository": {
     "type": "git",

--- a/test/unit/core/specific.spec.js
+++ b/test/unit/core/specific.spec.js
@@ -133,6 +133,58 @@ describe('Specific', function() {
             subscribe(noOp, done, done);
     });
 
+    it('should not follow references if no keys specified after path to reference', function (done) {
+        var routeResponse = {
+            "jsong": {
+                "ProffersById": {
+                    "1": {
+                        "ProductsList": {
+                            "0": {
+                                "$size": 52,
+                                "$type": "ref",
+                                "value": [
+                                    "ProductsById",
+                                    "CSC1471105X"
+                                ]
+                            },
+                            "1": {
+                                "$size": 52,
+                                "$type": "ref",
+                                "value": [
+                                    "ProductsById",
+                                    "HON4033T"
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        var router = new R([
+            {
+                route: "ProductsById[{keys}][{keys}]",
+                get: function (pathSet) {
+                    throw "reference was followed in error";
+                }
+            },
+            {
+                route: "ProffersById[{integers}].ProductsList[{ranges}]",
+                get: function (pathSet) {
+                    return Observable.of(routeResponse);
+                }
+            }
+        ]);
+        var obs = router.get([["ProffersById", 1, "ProductsList", {"from": 0, "to": 1}]]);
+        var called = false;
+        obs.subscribe(function (res) {
+            expect(res).to.deep.equals(routeResponse);
+            called = true;
+        }, done, function () {
+            expect(called, 'expect onNext called 1 time.').to.equal(true);
+            done();
+        });
+    });
+
     function getPrecedenceRouter(onTitle, onRating) {
         return new R([{
             route: 'videos[{integers:ids}].title',


### PR DESCRIPTION
…ough their target is not requested. Problem only manifests if route exists along the reference path.

Reviewed by @jhusain 
