### PR TITLE
Fixed falsey atom values being treated missing paths

### DIFF
--- a/src/cache/optimizePathSets.js
+++ b/src/cache/optimizePathSets.js
@@ -31,20 +31,20 @@ function optimizePathSet(cache, cacheRoot, pathSet,
                          depth, out, optimizedPath, maxRefFollow) {
 
     // at missing, report optimized path.
-    if (!cache) {
+    if (cache === undefined) {
         out[out.length] = catAndSlice(optimizedPath, pathSet, depth);
+        return;
+    }
+
+    // all other sentinels are short circuited.
+    // Or we found a primitive (which includes null)
+    if (cache === null || (cache.$type && cache.$type !== $ref) || (typeof cache !== 'object')) {
         return;
     }
 
     // If the reference is the last item in the path then do not
     // continue to search it.
     if (cache.$type === $ref && depth === pathSet.length) {
-        return;
-    }
-
-    // all other sentinels are short circuited.
-    // Or we found a primitive.
-    if (cache.$type && cache.$type !== $ref || typeof cache !== 'object') {
         return;
     }
 

--- a/src/cache/optimizePathSets.js
+++ b/src/cache/optimizePathSets.js
@@ -38,7 +38,8 @@ function optimizePathSet(cache, cacheRoot, pathSet,
 
     // all other sentinels are short circuited.
     // Or we found a primitive (which includes null)
-    if (cache === null || (cache.$type && cache.$type !== $ref) || (typeof cache !== 'object')) {
+    if (cache === null || (cache.$type && cache.$type !== $ref) ||
+            (typeof cache !== 'object')) {
         return;
     }
 

--- a/test/data/VideoRoutes.js
+++ b/test/data/VideoRoutes.js
@@ -109,66 +109,7 @@ module.exports = function() {
                     }
                 }];
             }
-        },
-        Falsey: function () {
-            return [{
-                route: 'videos.falsey.zero',
-                get: function(path) {
-                    return Observable.return({
-                        jsonGraph: {
-                            videos: {
-                                falsey: {
-                                    zero: $atom(0)
-                                }
-                            }
-                        },
-                        paths: [['videos', 'falsey', 'zero']]
-                    });
-                }
-            }, {
-                route: 'videos.falsey.null',
-                get: function(path) {
-                    return Observable.return({
-                        jsonGraph: {
-                            videos: {
-                                falsey: {
-                                    'null': $atom(null)
-                                }
-                            }
-                        },
-                        paths: [['videos', 'falsey', 'null']]
-                    });
-                }
-            }, {
-                route: 'videos.falsey.emptystring',
-                get: function(path) {
-                    return Observable.return({
-                        jsonGraph: {
-                            videos: {
-                                falsey: {
-                                    'emptystring': $atom('')
-                                }
-                            }
-                        },
-                        paths: [['videos', 'falsey', 'emptystring']]
-                    });
-                }
-            }, {
-                route: 'videos.falsey.false',
-                get: function(path) {
-                    return Observable.return({
-                        jsonGraph: {
-                            videos: {
-                                falsey: {
-                                    'false': $atom(false)
-                                }
-                            }
-                        },
-                        paths: [['videos', 'falsey', 'false']]
-                    });
-                }
-            }];
-        },
+        }
     };
 };
 

--- a/test/data/VideoRoutes.js
+++ b/test/data/VideoRoutes.js
@@ -109,7 +109,66 @@ module.exports = function() {
                     }
                 }];
             }
-        }
+        },
+        Falsey: function () {
+            return [{
+                route: 'videos.falsey.zero',
+                get: function(path) {
+                    return Observable.return({
+                        jsonGraph: {
+                            videos: {
+                                falsey: {
+                                    zero: $atom(0)
+                                }
+                            }
+                        },
+                        paths: [['videos', 'falsey', 'zero']]
+                    });
+                }
+            }, {
+                route: 'videos.falsey.null',
+                get: function(path) {
+                    return Observable.return({
+                        jsonGraph: {
+                            videos: {
+                                falsey: {
+                                    'null': $atom(null)
+                                }
+                            }
+                        },
+                        paths: [['videos', 'falsey', 'null']]
+                    });
+                }
+            }, {
+                route: 'videos.falsey.emptystring',
+                get: function(path) {
+                    return Observable.return({
+                        jsonGraph: {
+                            videos: {
+                                falsey: {
+                                    'emptystring': $atom('')
+                                }
+                            }
+                        },
+                        paths: [['videos', 'falsey', 'emptystring']]
+                    });
+                }
+            }, {
+                route: 'videos.falsey.false',
+                get: function(path) {
+                    return Observable.return({
+                        jsonGraph: {
+                            videos: {
+                                falsey: {
+                                    'false': $atom(false)
+                                }
+                            }
+                        },
+                        paths: [['videos', 'falsey', 'false']]
+                    });
+                }
+            }];
+        },
     };
 };
 

--- a/test/unit/core/get.spec.js
+++ b/test/unit/core/get.spec.js
@@ -6,7 +6,6 @@ var chai = require('chai');
 var expect = chai.expect;
 var falcor = require('falcor');
 var $ref = falcor.Model.ref;
-var $atom = require('./../../../src/support/types').$atom;
 var Observable = require('rx').Observable;
 var sinon = require('sinon');
 
@@ -26,23 +25,28 @@ describe('Get', function() {
         });
     });
 
-    it('should not return empty atoms for a null value', function(done) {
-        var router = new R(Routes().Videos.Falsey());
+    it('should not return empty atoms for a zero path value', function(done) {
+
+        var router = new R([{
+                route: 'videos.falsey',
+                get: function(path) {
+                    return Observable.return({
+                        value: 0,
+                        path: ['videos', 'falsey']
+                    });
+                }
+        }]);
+
         var onNext = sinon.spy();
 
-        router.get([['videos', 'falsey', 'null']]).
+        router.get([['videos', 'falsey']]).
             doAction(onNext).
             doAction(noOp, noOp, function() {
                 expect(onNext.calledOnce).to.be.ok;
                 expect(onNext.getCall(0).args[0]).to.deep.equals({
                     jsonGraph: {
                         videos: {
-                            falsey: {
-                                'null': {
-                                    $type: $atom,
-                                    value: null
-                                }
-                            }
+                            falsey: 0
                         }
                     }
                 });
@@ -50,23 +54,29 @@ describe('Get', function() {
             subscribe(noOp, done, done);
     });
 
-    it('should not return empty atoms for a zero value', function(done) {
-        var router = new R(Routes().Videos.Falsey());
+    // Needs fix for https://github.com/Netflix/falcor-router/issues/120 in pathValueMerge.js
+    xit('should not return empty atoms for a null path value', function(done) {
+
+        var router = new R([{
+                route: 'videos.falsey',
+                get: function(path) {
+                    return Observable.return({
+                        value: null,
+                        path: ['videos', 'falsey']
+                    });
+                }
+        }]);
+
         var onNext = sinon.spy();
 
-        router.get([['videos', 'falsey', 'zero']]).
+        router.get([['videos', 'falsey']]).
             doAction(onNext).
             doAction(noOp, noOp, function() {
                 expect(onNext.calledOnce).to.be.ok;
                 expect(onNext.getCall(0).args[0]).to.deep.equals({
                     jsonGraph: {
                         videos: {
-                            falsey: {
-                                zero: {
-                                    $type: $atom,
-                                    value: 0
-                                }
-                            }
+                            falsey: null
                         }
                     }
                 });
@@ -74,23 +84,28 @@ describe('Get', function() {
             subscribe(noOp, done, done);
     });
 
-    it('should not return empty atoms for an empty string value', function(done) {
-        var router = new R(Routes().Videos.Falsey());
+    it('should not return empty atoms for a false path value', function(done) {
+
+        var router = new R([{
+                route: 'videos.falsey',
+                get: function(path) {
+                    return Observable.return({
+                        value: false,
+                        path: ['videos', 'falsey']
+                    });
+                }
+        }]);
+
         var onNext = sinon.spy();
 
-        router.get([['videos', 'falsey', 'emptystring']]).
+        router.get([['videos', 'falsey']]).
             doAction(onNext).
             doAction(noOp, noOp, function() {
                 expect(onNext.calledOnce).to.be.ok;
                 expect(onNext.getCall(0).args[0]).to.deep.equals({
                     jsonGraph: {
                         videos: {
-                            falsey: {
-                                emptystring: {
-                                    $type: $atom,
-                                    value: ''
-                                }
-                            }
+                            falsey: false
                         }
                     }
                 });
@@ -98,23 +113,28 @@ describe('Get', function() {
             subscribe(noOp, done, done);
     });
 
-    it('should not return empty atoms for a false value', function(done) {
-        var router = new R(Routes().Videos.Falsey());
+    it('should not return empty atoms for a empty string path value', function(done) {
+
+        var router = new R([{
+                route: 'videos.falsey',
+                get: function(path) {
+                    return Observable.return({
+                        value: '',
+                        path: ['videos', 'falsey']
+                    });
+                }
+        }]);
+
         var onNext = sinon.spy();
 
-        router.get([['videos', 'falsey', 'false']]).
+        router.get([['videos', 'falsey']]).
             doAction(onNext).
             doAction(noOp, noOp, function() {
                 expect(onNext.calledOnce).to.be.ok;
                 expect(onNext.getCall(0).args[0]).to.deep.equals({
                     jsonGraph: {
                         videos: {
-                            falsey: {
-                                'false': {
-                                    $type: $atom,
-                                    value: false
-                                }
-                            }
+                            falsey: ''
                         }
                     }
                 });

--- a/test/unit/core/get.spec.js
+++ b/test/unit/core/get.spec.js
@@ -6,10 +6,12 @@ var chai = require('chai');
 var expect = chai.expect;
 var falcor = require('falcor');
 var $ref = falcor.Model.ref;
+var $atom = require('./../../../src/support/types').$atom;
 var Observable = require('rx').Observable;
 var sinon = require('sinon');
 
 describe('Get', function() {
+
     it('should execute a simple route matching.', function(done) {
         var router = new R(Routes().Videos.Summary());
         var obs = router.
@@ -22,6 +24,102 @@ describe('Get', function() {
             expect(called, 'expect onNext called 1 time.').to.equal(true);
             done();
         });
+    });
+
+    it('should not return empty atoms for a null value', function(done) {
+        var router = new R(Routes().Videos.Falsey());
+        var onNext = sinon.spy();
+
+        router.get([['videos', 'falsey', 'null']]).
+            doAction(onNext).
+            doAction(noOp, noOp, function() {
+                expect(onNext.calledOnce).to.be.ok;
+                expect(onNext.getCall(0).args[0]).to.deep.equals({
+                    jsonGraph: {
+                        videos: {
+                            falsey: {
+                                'null': {
+                                    $type: $atom,
+                                    value: null
+                                }
+                            }
+                        }
+                    }
+                });
+            }).
+            subscribe(noOp, done, done);
+    });
+
+    it('should not return empty atoms for a zero value', function(done) {
+        var router = new R(Routes().Videos.Falsey());
+        var onNext = sinon.spy();
+
+        router.get([['videos', 'falsey', 'zero']]).
+            doAction(onNext).
+            doAction(noOp, noOp, function() {
+                expect(onNext.calledOnce).to.be.ok;
+                expect(onNext.getCall(0).args[0]).to.deep.equals({
+                    jsonGraph: {
+                        videos: {
+                            falsey: {
+                                zero: {
+                                    $type: $atom,
+                                    value: 0
+                                }
+                            }
+                        }
+                    }
+                });
+            }).
+            subscribe(noOp, done, done);
+    });
+
+    it('should not return empty atoms for an empty string value', function(done) {
+        var router = new R(Routes().Videos.Falsey());
+        var onNext = sinon.spy();
+
+        router.get([['videos', 'falsey', 'emptystring']]).
+            doAction(onNext).
+            doAction(noOp, noOp, function() {
+                expect(onNext.calledOnce).to.be.ok;
+                expect(onNext.getCall(0).args[0]).to.deep.equals({
+                    jsonGraph: {
+                        videos: {
+                            falsey: {
+                                emptystring: {
+                                    $type: $atom,
+                                    value: ''
+                                }
+                            }
+                        }
+                    }
+                });
+            }).
+            subscribe(noOp, done, done);
+    });
+
+    it('should not return empty atoms for a false value', function(done) {
+        var router = new R(Routes().Videos.Falsey());
+        var onNext = sinon.spy();
+
+        router.get([['videos', 'falsey', 'false']]).
+            doAction(onNext).
+            doAction(noOp, noOp, function() {
+                expect(onNext.calledOnce).to.be.ok;
+                expect(onNext.getCall(0).args[0]).to.deep.equals({
+                    jsonGraph: {
+                        videos: {
+                            falsey: {
+                                'false': {
+                                    $type: $atom,
+                                    value: false
+                                }
+                            }
+                        }
+                    }
+                });
+            }).
+            subscribe(noOp, done, done);
     });
 
     it('should validate that optimizedPathSets strips out already found data.', function(done) {

--- a/test/unit/internal/optimizePathSets.spec.js
+++ b/test/unit/internal/optimizePathSets.spec.js
@@ -66,6 +66,33 @@ describe('optimizePathSets', function() {
         expect(out).to.deep.equal(expected);
     });
 
+    it('should short circuit on primitive string values', function() {
+        var cache = getCache();
+        var paths = [['videos', '6', 'summary']];
+
+        var out = optimizePathSets(cache, paths);
+        var expected = [];
+        expect(out).to.deep.equal(expected);
+    });
+
+    it('should short circuit on primitive number values', function() {
+        var cache = getCache();
+        var paths = [['videos', '7', 'summary']];
+
+        var out = optimizePathSets(cache, paths);
+        var expected = [];
+        expect(out).to.deep.equal(expected);
+    });
+
+    it('should short circuit on primitive boolean values', function() {
+        var cache = getCache();
+        var paths = [['videos', '8', 'summary']];
+
+        var out = optimizePathSets(cache, paths);
+        var expected = [];
+        expect(out).to.deep.equal(expected);
+    });
+
     it('should throw.', function() {
         var cache = getCache();
         var paths = [['videosList', 'inner', 'summary']];
@@ -79,6 +106,7 @@ describe('optimizePathSets', function() {
         }
         expect(caught).to.equals(true);
     });
+
 });
 
 function getCache() {
@@ -91,7 +119,18 @@ function getCache() {
             inner: $ref('videosList[3].inner')
         },
         videos: {
-            5: $atom('title')
+            5: $atom('title'),
+
+            // Short circuit on primitives
+            6: $atom('a'),
+            7: $atom(1),
+            8: $atom(true),
+
+            // Falsey edge cases
+            9: $atom(''),
+            10: $atom(0),
+            11: $atom(false),
+            12: $atom(null)
         }
     };
 }

--- a/test/unit/internal/optimizePathSets.spec.js
+++ b/test/unit/internal/optimizePathSets.spec.js
@@ -93,6 +93,51 @@ describe('optimizePathSets', function() {
         expect(out).to.deep.equal(expected);
     });
 
+    it('should short circuit on primitive null value', function() {
+        var cache = getCache();
+        var paths = [['videos', '9', 'summary']];
+
+        var out = optimizePathSets(cache, paths);
+        var expected = [];
+        expect(out).to.deep.equal(expected);
+    });
+
+    it('should not treat falsey string as missing', function() {
+        var cache = getCache();
+        var paths = [['falsey', 'string']];
+
+        var out = optimizePathSets(cache, paths);
+        var expected = [];
+        expect(out).to.deep.equal(expected);
+    });
+
+    it('should not treat falsey number as missing', function() {
+        var cache = getCache();
+        var paths = [['falsey', 'number']];
+
+        var out = optimizePathSets(cache, paths);
+        var expected = [];
+        expect(out).to.deep.equal(expected);
+    });
+
+    it('should not treat falsey boolean as missing', function() {
+        var cache = getCache();
+        var paths = [['falsey', 'boolean']];
+
+        var out = optimizePathSets(cache, paths);
+        var expected = [];
+        expect(out).to.deep.equal(expected);
+    });
+
+    it('should not treat falsey null as missing', function() {
+        var cache = getCache();
+        var paths = [['falsey', 'null']];
+
+        var out = optimizePathSets(cache, paths);
+        var expected = [];
+        expect(out).to.deep.equal(expected);
+    });
+
     it('should throw.', function() {
         var cache = getCache();
         var paths = [['videosList', 'inner', 'summary']];
@@ -122,15 +167,16 @@ function getCache() {
             5: $atom('title'),
 
             // Short circuit on primitives
-            6: $atom('a'),
-            7: $atom(1),
-            8: $atom(true),
-
-            // Falsey edge cases
-            9: $atom(''),
-            10: $atom(0),
-            11: $atom(false),
-            12: $atom(null)
+            6: 'a',
+            7: 1,
+            8: true,
+            9: null
+        },
+        falsey: {
+            string: '',
+            number: 0,
+            boolean: false,
+            'null': null
         }
     };
 }


### PR DESCRIPTION
@michaelbpaulson 

Paths which returned falsey values (null, 0, false, '') were being
treated as missing paths, and hence being returned as empty atoms.

See: https://github.com/Netflix/falcor/issues/460

Sending this over for an initial review. This does fix the reported issue, however I still need to work on the `get` tests. I don't think they're testing the right use case, because they pass with the older code too.

I don't think we should merge until I've sorted out the right set of unit and integration tests.