### PR TITLE
version changed of path syntax.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "rx": "~2.5.3",
-    "falcor-path-syntax": "0.2.1",
+    "falcor-path-syntax": "0.2.2",
     "falcor-path-utils": "0.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "chai": "^2.3.0",
     "coveralls": "^2.11.2",
-    "falcor": "0.1.4",
+    "falcor": "0.1.12",
     "gulp": "~3.8.11",
     "gulp-bump": "~0.1.13",
     "gulp-clean": "~0.3.1",


### PR DESCRIPTION
I think this was causing the build failure, but I have no idea why.  At least I was able to `npm i` from a clean repo.