### PR TITLE
Fixes NPEs when route returns a path with a value of null

### DIFF
--- a/src/cache/pathValueMerge.js
+++ b/src/cache/pathValueMerge.js
@@ -19,7 +19,7 @@ module.exports = function pathValueMerge(cache, pathValue) {
 
     // References.  Needed for evaluationg suffixes in
     // both call and get/set.
-    else if (pathValue.value.$type === $ref) {
+    else if ((pathValue.value !== null) && (pathValue.value.$type === $ref)) {
         refs.push({
             path: pathValue.path,
             value: pathValue.value.value

--- a/src/support/clone.js
+++ b/src/support/clone.js
@@ -1,5 +1,5 @@
 module.exports = function copy(valueType) {
-    if (typeof valueType !== 'object') {
+    if ((typeof valueType !== 'object') || (valueType === null)) {
         return valueType;
     }
 

--- a/test/unit/core/get.spec.js
+++ b/test/unit/core/get.spec.js
@@ -54,8 +54,7 @@ describe('Get', function() {
             subscribe(noOp, done, done);
     });
 
-    // Needs fix for https://github.com/Netflix/falcor-router/issues/120 in pathValueMerge.js
-    xit('should not return empty atoms for a null path value', function(done) {
+    it('should not return empty atoms for a null path value', function(done) {
 
         var router = new R([{
                 route: 'videos.falsey',


### PR DESCRIPTION
Couple of areas it was hitting NPEs:

* In pathValueMerge when trying to identify references.
* In the generic support/clone method, which wasn't accounting for null (good argument to use a lodash'esque library for this).

Un-X'ed the unit test which was added for this use case, which now passes.

Fixes #120 