### PR TITLE
Fixed falsey/null value issues in jsong merge

### DIFF
--- a/src/cache/jsongMerge.js
+++ b/src/cache/jsongMerge.js
@@ -44,13 +44,14 @@ function merge(config, cache, message, depth, path, fromParent, fromKey) {
     }
 
     // The message at this point should always be defined.
-    if (message.$type || typeOfMessage !== 'object') {
+    // Reached the end of the JSONG message path
+    if (message === null || typeOfMessage !== 'object' || message.$type) {
         fromParent[fromKey] = clone(message);
 
         // NOTE: If we have found a reference at our cloning position
         // and we have resolved our path then add the reference to
         // the unfulfilledRefernces.
-        if (message.$type === $ref) {
+        if (message && message.$type === $ref) {
             var references = config.references;
             references.push({
                 path: cloneArray(requestedPath),
@@ -65,7 +66,7 @@ function merge(config, cache, message, depth, path, fromParent, fromKey) {
             var values = config.values;
             values.push({
                 path: cloneArray(requestedPath),
-                value: message.type ? message.value : message
+                value: (message && message.type) ? message.value : message
             });
         }
 
@@ -85,6 +86,7 @@ function merge(config, cache, message, depth, path, fromParent, fromKey) {
         // just follow cache, else attempt to follow message.
         var cacheRes = cache[key];
         var messageRes = message[key];
+
         var nextPath = path;
         var nextDepth = depth + 1;
         if (updateRequestedPath) {
@@ -92,13 +94,13 @@ function merge(config, cache, message, depth, path, fromParent, fromKey) {
         }
 
         // Cache does not exist but message does.
-        if (!cacheRes) {
+        if (cacheRes === undefined) {
             cacheRes = cache[key] = {};
         }
 
         // TODO: Can we hit a leaf node in the cache when traversing?
 
-        if (messageRes) {
+        if (messageRes !== undefined) {
             var nextIgnoreCount = 0;
 
             // TODO: Potential performance gain since we know that
@@ -107,7 +109,7 @@ function merge(config, cache, message, depth, path, fromParent, fromKey) {
 
             // There is only a need to consider message references since the
             // merge is only for the path that is provided.
-            if (messageRes.$type === $ref && depth < path.length - 1) {
+            if (messageRes && messageRes.$type === $ref && depth < path.length - 1) {
                 nextDepth = 0;
                 nextPath = catAndSlice(messageRes.value, path, depth + 1);
                 cache[key] = clone(messageRes);

--- a/test/unit/core/get.spec.js
+++ b/test/unit/core/get.spec.js
@@ -6,6 +6,7 @@ var chai = require('chai');
 var expect = chai.expect;
 var falcor = require('falcor');
 var $ref = falcor.Model.ref;
+var $atom = falcor.Model.atom;
 var Observable = require('rx').Observable;
 var sinon = require('sinon');
 
@@ -23,6 +24,138 @@ describe('Get', function() {
             expect(called, 'expect onNext called 1 time.').to.equal(true);
             done();
         });
+    });
+
+    it('should not return empty atoms for a null value in jsonGraph', function(done) {
+
+        var router = new R([{
+                route: 'videos.falsey',
+                get: function(path) {
+                    return Observable.return({
+                        jsonGraph: {
+                            videos: {
+                                falsey: null
+                            }
+                        },
+                        paths: [['videos', 'falsey']]
+                    });
+                }
+        }]);
+
+        var onNext = sinon.spy();
+
+        router.get([['videos', 'falsey']]).
+            doAction(onNext).
+            doAction(noOp, noOp, function() {
+                expect(onNext.calledOnce).to.be.ok;
+                expect(onNext.getCall(0).args[0]).to.deep.equals({
+                    jsonGraph: {
+                        videos: {
+                            falsey: null
+                        }
+                    }
+                });
+            }).
+            subscribe(noOp, done, done);
+    });
+
+    it('should not return empty atoms for a null value atom in jsonGraph', function(done) {
+
+        var router = new R([{
+                route: 'videos.falsey',
+                get: function(path) {
+                    return Observable.return({
+                        jsonGraph: {
+                            videos: {
+                                falsey: $atom(null)
+                            }
+                        },
+                        paths: [['videos', 'falsey']]
+                    });
+                }
+        }]);
+
+        var onNext = sinon.spy();
+
+        router.get([['videos', 'falsey']]).
+            doAction(onNext).
+            doAction(noOp, noOp, function() {
+                expect(onNext.calledOnce).to.be.ok;
+                expect(onNext.getCall(0).args[0]).to.deep.equals({
+                    jsonGraph: {
+                        videos: {
+                            falsey: $atom(null)
+                        }
+                    }
+                });
+            }).
+            subscribe(noOp, done, done);
+    });
+
+    it('should not return empty atoms for a zero value in jsonGraph', function(done) {
+
+        var router = new R([{
+                route: 'videos.falsey',
+                get: function(path) {
+                    return Observable.return({
+                        jsonGraph: {
+                            videos: {
+                                falsey: 0
+                            }
+                        },
+                        paths: [['videos', 'falsey']]
+                    });
+                }
+        }]);
+
+        var onNext = sinon.spy();
+
+        router.get([['videos', 'falsey']]).
+            doAction(onNext).
+            doAction(noOp, noOp, function() {
+                expect(onNext.calledOnce).to.be.ok;
+                expect(onNext.getCall(0).args[0]).to.deep.equals({
+                    jsonGraph: {
+                        videos: {
+                            falsey: 0
+                        }
+                    }
+                });
+            }).
+            subscribe(noOp, done, done);
+    });
+
+    it('should not return empty atoms for a zero value atom in jsonGraph', function(done) {
+
+        var router = new R([{
+                route: 'videos.falsey',
+                get: function(path) {
+                    return Observable.return({
+                        jsonGraph: {
+                            videos: {
+                                falsey: $atom(0)
+                            }
+                        },
+                        paths: [['videos', 'falsey']]
+                    });
+                }
+        }]);
+
+        var onNext = sinon.spy();
+
+        router.get([['videos', 'falsey']]).
+            doAction(onNext).
+            doAction(noOp, noOp, function() {
+                expect(onNext.calledOnce).to.be.ok;
+                expect(onNext.getCall(0).args[0]).to.deep.equals({
+                    jsonGraph: {
+                        videos: {
+                            falsey: $atom(0)
+                        }
+                    }
+                });
+            }).
+            subscribe(noOp, done, done);
     });
 
     it('should not return empty atoms for a zero path value', function(done) {

--- a/test/unit/internal/jsongMerge.spec.js
+++ b/test/unit/internal/jsongMerge.spec.js
@@ -13,6 +13,7 @@ var _ = require('lodash');
  * are.
  */
 describe('JSONG - Merge', function() {
+
     it('should write a simple path to the cache.', function() {
 
         var jsong = {
@@ -33,6 +34,91 @@ describe('JSONG - Merge', function() {
             references: []
         });
     });
+
+    it('should write a falsey number to the cache.', function() {
+
+        var jsong = {
+            jsonGraph: {
+                there: {
+                    is: 0
+                }
+            },
+            paths: [['there', 'is']]
+        };
+
+        var out = mergeTest(jsong);
+        expect(out).to.deep.equals({
+            values: [{
+                path: ['there', 'is'],
+                value: 0
+            }],
+            references: []
+        });
+    });
+
+    it('should write a falsey string to the cache.', function() {
+
+        var jsong = {
+            jsonGraph: {
+                there: {
+                    is: ''
+                }
+            },
+            paths: [['there', 'is']]
+        };
+
+        var out = mergeTest(jsong);
+        expect(out).to.deep.equals({
+            values: [{
+                path: ['there', 'is'],
+                value: ''
+            }],
+            references: []
+        });
+    });
+
+    it('should write a false boolean to the cache.', function() {
+
+        var jsong = {
+            jsonGraph: {
+                there: {
+                    is: false
+                }
+            },
+            paths: [['there', 'is']]
+        };
+
+        var out = mergeTest(jsong);
+        expect(out).to.deep.equals({
+            values: [{
+                path: ['there', 'is'],
+                value: false
+            }],
+            references: []
+        });
+    });
+
+    it('should write a null to the cache.', function() {
+
+        var jsong = {
+            jsonGraph: {
+                there: {
+                    is: null
+                }
+            },
+            paths: [['there', 'is']]
+        };
+
+        var out = mergeTest(jsong);
+        expect(out).to.deep.equals({
+            values: [{
+                path: ['there', 'is'],
+                value: null
+            }],
+            references: []
+        });
+    });
+
     it('should write a path with a reference to a value.', function() {
         var jsong = {
             jsonGraph: {
@@ -47,6 +133,7 @@ describe('JSONG - Merge', function() {
         };
         mergeTest(jsong);
     });
+
     it('should write a path with a reference to a branch.', function() {
 
         var jsong = {
@@ -63,6 +150,7 @@ describe('JSONG - Merge', function() {
 
         mergeTest(jsong);
     });
+
     it('should write a path with a reference to a reference.', function() {
         var jsong = {
             jsonGraph: {
@@ -77,6 +165,7 @@ describe('JSONG - Merge', function() {
 
         mergeTest(jsong);
     });
+
     it('should get the set refs.', function() {
         var jsong = {
             jsonGraph: {


### PR DESCRIPTION
@michaelbpaulson 

This fixes the falsey issues similar to the ones mentioned in https://github.com/Netflix/falcor/issues/460 and https://github.com/Netflix/falcor-router/issues/120 but this time for JSONG (issues in jsongMerge this time, last time it was in optimizePathSet).