### PR TITLE
Bump up router version, to pick up falcor-path-syntax changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falcor-router",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "A router DataSource constructor for falcor that allows you to model all your cloud data sources as a single JSON resource.",
   "main": "src/Router.js",
   "homepage": "https://github.com/Netflix/falcor-router",
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "rx": "~2.5.3",
-    "falcor-path-syntax": "0.2.2",
+    "falcor-path-syntax": "0.2.3",
     "falcor-path-utils": "0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Needed to bump up the falcor-router semver (will be doing the same for falcor also), since we're changing the hard-versioned dep for falcor-path-syntax to pick up some "use strict" related fixes.

Was actually looking for some npm best-practice feedback here.

This seems like the right thing to do (bump up the semver for the module, since one of it's deps got bumped), but wanted to see if anyone had any alternate suggestions, assuming we want to keep dependency versions fixed, as opposed to using a wildcard, for now.

Will publish to npm, once merged.