### PR TITLE
bug(precedence): There was a matching issue with precedence.

### DIFF
--- a/src/operations/matcher/index.js
+++ b/src/operations/matcher/index.js
@@ -175,6 +175,22 @@ function match(
         };
     }
 
+    // If the depth has reached the end then we need to stop recursing.  This
+    // can cause odd side effects with matching against {keys} as the last
+    // argument when a path has been exhausted (undefined is still a key value).
+    //
+    // Example:
+    // route1: [{keys}]
+    // route2: [{keys}][{keys}]
+    //
+    // path: ['('].
+    //
+    // This will match route1 and 2 since we do not bail out on length and there
+    // is a {keys} matcher which will match "undefined" value.
+    if (depth === path.length) {
+        return;
+    }
+
     var keySet = path[depth];
     var i, len, key, next;
 

--- a/test/unit/functional/index.js
+++ b/test/unit/functional/index.js
@@ -4,4 +4,5 @@ describe('Functional', function() {
     require('./virtual-collision.spec');
     require('./materialized.spec');
     require('./unhandled.spec');
+    require('./predence.spec');
 });

--- a/test/unit/functional/precedence.spec.js
+++ b/test/unit/functional/precedence.spec.js
@@ -1,0 +1,32 @@
+var R = require('../../../src/Router');
+var noOp = function() {};
+var chai = require('chai');
+var expect = chai.expect;
+var Observable = require('rx').Observable;
+var sinon = require('sinon');
+
+describe('Precedence Matching', function() {
+    it('should properly precedence match with different lengths.', function(done) {
+        var shortGet = sinon.spy(function() {
+            return Observable.empty();
+        });
+        var longerGet = sinon.spy(function() {
+            return Observable.empty();
+        });
+        var router = new R([{
+            route: 'get[{integers}][{keys}]',
+            get: shortGet
+        }, {
+            route: 'get[{integers}][{keys}][{keys}]',
+            get: longerGet
+        }]);
+
+        router.
+            get([['get', 11, 'six']]).
+            doAction(noOp, noOp, function() {
+                expect(longerGet.callCount).to.equals(0);
+                expect(shortGet.callCount).to.equals(1);
+            }).
+            subscribe(noOp, done, done);
+    });
+});


### PR DESCRIPTION
There was a matching issue with precedence.  It involved not stopping
when the depth is equivalent to the path length.  This could cause
problems on a very corner case.  Essentially if 2 paths have the same
route except one route is longer with {keys} matcher at the end.

E.G
var router = new Router([{
    route: 'the.force.awakens',
    get: ...
}, {
    route: 'the.force.awakens[{keys}]',
    get: ...
}]);

// This would match both routes since the matching algorithm would not
// stop at the end of the path and `undefined` is a {keys} value.
router.get([['the', 'force', 'awakens']]).subscribe(...);

@sdesai 