### PR TITLE
feat(onUnhandled*): decided on the name of the API.

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -66,7 +66,7 @@ Router.prototype = {
      * have a chance to fulfill that request.
      * @param {DataSource} dataSource -
      */
-    onUnhandledOperation: function unhandledDataSource(dataSource) {
+    routeUnhandledPathsTo: function routeUnhandledPathsTo(dataSource) {
         this._unhandled = dataSource;
     }
 };

--- a/test/unit/functional/unhandled.call.spec.js
+++ b/test/unit/functional/unhandled.call.spec.js
@@ -20,7 +20,7 @@ describe('#call', function() {
                 ]
             });
         });
-        router.onUnhandledOperation({
+        router.routeUnhandledPathsTo({
             call: onCall
         });
         var onNext = sinon.spy();
@@ -52,7 +52,7 @@ describe('#call', function() {
                 ]
             });
         });
-        router.onUnhandledOperation({
+        router.routeUnhandledPathsTo({
             call: onCall
         });
         var onNext = sinon.spy();

--- a/test/unit/functional/unhandled.get.spec.js
+++ b/test/unit/functional/unhandled.get.spec.js
@@ -13,7 +13,7 @@ describe('#get', function() {
         var onUnhandledPaths = sinon.spy(function convert(paths) {
             return Observable.empty();
         });
-        router.onUnhandledOperation({get: onUnhandledPaths});
+        router.routeUnhandledPathsTo({get: onUnhandledPaths});
 
         var obs = router.
             get([['videos', 'summary']]);
@@ -35,7 +35,7 @@ describe('#get', function() {
             }).
             subscribe(noOp, done, done);
     });
-    it('should call the onUnhandledOperation when the route completely misses a route.', function(done) {
+    it('should call the routeUnhandledPathsTo when the route completely misses a route.', function(done) {
         var router = new R([]);
         var onUnhandledPaths = sinon.spy(function convert(paths) {
             var returnValue = paths.reduce(function(jsonGraph, path) {
@@ -47,7 +47,7 @@ describe('#get', function() {
             }, {jsonGraph: {}});
             return Observable.return(returnValue);
         });
-        router.onUnhandledOperation({get: onUnhandledPaths});
+        router.routeUnhandledPathsTo({get: onUnhandledPaths});
 
         var obs = router.
             get([['videos', 'summary']]);
@@ -70,7 +70,7 @@ describe('#get', function() {
             subscribe(noOp, done, done);
     });
 
-    it('should call the onUnhandledOperation when the route partially misses a route.', function(done) {
+    it('should call the routeUnhandledPathsTo when the route partially misses a route.', function(done) {
         var router = new R([{
             route: 'videos.length',
             get: function() {
@@ -90,7 +90,7 @@ describe('#get', function() {
             }, {jsonGraph: {}});
             return Observable.return(returnValue);
         });
-        router.onUnhandledOperation({get: onUnhandledPaths});
+        router.routeUnhandledPathsTo({get: onUnhandledPaths});
 
         var obs = router.
             get([['videos', ['length', 'summary']]]);

--- a/test/unit/functional/unhandled.set.spec.js
+++ b/test/unit/functional/unhandled.set.spec.js
@@ -14,7 +14,7 @@ describe('#set', function() {
         var onUnhandledPaths = sinon.spy(function convert(paths) {
             return Observable.empty();
         });
-        router.onUnhandledOperation({set: onUnhandledPaths});
+        router.routeUnhandledPathsTo({set: onUnhandledPaths});
 
         var obs = router.
             set({
@@ -52,7 +52,7 @@ describe('#set', function() {
             }).
             subscribe(noOp, done, done);
     });
-    it('should call the onUnhandledOperation when the route completely misses a route.', function(done) {
+    it('should call the routeUnhandledPathsTo when the route completely misses a route.', function(done) {
         var router = new R([]);
         var onUnhandledPaths = sinon.spy(function convert(jsonGraphEnv) {
             var returnValue = jsonGraphEnv.paths.reduce(function(jsonGraph, path) {
@@ -65,7 +65,7 @@ describe('#set', function() {
 
             return Observable.return(returnValue);
         });
-        router.onUnhandledOperation({set: onUnhandledPaths});
+        router.routeUnhandledPathsTo({set: onUnhandledPaths});
 
         var obs = router.
             set({
@@ -104,7 +104,7 @@ describe('#set', function() {
             subscribe(noOp, done, done);
     });
 
-    it('should call the onUnhandledOperation when the route partially misses a route.', function(done) {
+    it('should call the routeUnhandledPathsTo when the route partially misses a route.', function(done) {
         var router = new R([{
             route: 'videos.length',
             set: function() {
@@ -124,7 +124,7 @@ describe('#set', function() {
             }, {jsonGraph: {}});
             return Observable.return(returnValue);
         });
-        router.onUnhandledOperation({set: onUnhandledPaths});
+        router.routeUnhandledPathsTo({set: onUnhandledPaths});
 
         var obs = router.
             set({
@@ -204,7 +204,7 @@ describe('#set', function() {
             });
             return Observable.return(next);
         });
-        router.onUnhandledOperation({set: onUnhandledPaths});
+        router.routeUnhandledPathsTo({set: onUnhandledPaths});
 
         var obs = router.
             set({


### PR DESCRIPTION
@sdesai @jhusain @ktrott 

This is the last change that is required to be able to _minor_ rev the router.  We should be able to use conventional-changelog to generate the changelog.md