### PR TITLE
fix(empty-call): Call could not return nothing

### DIFF
--- a/src/run/call/runCallAction.js
+++ b/src/run/call/runCallAction.js
@@ -45,15 +45,27 @@ function runCallAction(matchAndPath, routerInstance, callPath, args,
             // Required to get the references from the outputting jsong
             // and pathValues.
             map(function(res) {
+
                 // checks call for isJSONG and if there is jsong without paths
                 // throw errors.
                 var refs = [];
                 var values = [];
 
                 // Will flatten any arrays of jsong/pathValues.
-                var callOutput = res.reduce(function(flattenedRes, next) {
-                    return flattenedRes.concat(next);
-                }, []);
+                var callOutput = res.
+
+                    // Filters out any falsy values
+                    filter(function(x) {
+                        return x;
+                    }).
+                    reduce(function(flattenedRes, next) {
+                        return flattenedRes.concat(next);
+                    }, []);
+
+                // An empty output from call
+                if (callOutput.length === 0) {
+                    return [];
+                }
 
                 var refLen = -1;
                 callOutput.forEach(function(r) {

--- a/test/unit/core/call.spec.js
+++ b/test/unit/core/call.spec.js
@@ -15,6 +15,47 @@ var CallNotFoundError = require('./../../../src/errors/CallNotFoundError');
 var CallRequiresPathsError = require('./../../../src/errors/CallRequiresPathsError');
 
 describe('Call', function() {
+    it('should be able to return nothing from a call', function(done) {
+        var router = new R([{
+            route: 'a.b',
+            call: function(callPath, args) {
+                return undefined;
+            }
+        }]);
+
+        var onNext = sinon.spy();
+        router.
+            call(['a', 'b']).
+            doAction(onNext, noOp, function() {
+                expect(onNext.calledOnce, 'onNext called once').to.be.ok;
+                expect(onNext.getCall(0).args[0]).to.deep.equals({
+                    jsonGraph: {},
+                    paths: []
+                });
+            }).
+            subscribe(noOp, done, done);
+    });
+
+    it('should be able to return empty array from a call', function(done) {
+        var router = new R([{
+            route: 'a.b',
+            call: function(callPath, args) {
+                return [];
+            }
+        }]);
+
+        var onNext = sinon.spy();
+        router.
+            call(['a', 'b']).
+            doAction(onNext, noOp, function() {
+                expect(onNext.calledOnce, 'onNext called once').to.be.ok;
+                expect(onNext.getCall(0).args[0]).to.deep.equals({
+                    jsonGraph: {},
+                    paths: []
+                });
+            }).
+            subscribe(noOp, done, done);
+    });
 
     it('should bind "this" properly on a call that tranverses through a reference.', function(done) {
         var values = [];


### PR DESCRIPTION
Call functions could not return `undefined` or `[]` without throwing an
error.  Now both are valid output from a call function in which it will
assume that nothing has to be subscribed / then'd to and go along its
merry way processing.

Closes #166