### PR TITLE
Adding maxPaths option to Router.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "falcor-path-syntax": "0.2.4",
-    "falcor-path-utils": "0.3.0",
-    "rx": "^4.0.7"
+    "rx": "^4.0.7",
+    "falcor-path-utils": "~0.5.0"
   },
   "devDependencies": {
     "chai": "^2.3.0",

--- a/src/Router.js
+++ b/src/Router.js
@@ -3,6 +3,7 @@ var parseTree = require('./parse-tree');
 var matcher = require('./operations/matcher');
 var JSONGraphError = require('./errors/JSONGraphError');
 var MAX_REF_FOLLOW = 50;
+var MAX_PATHS = 9000;
 
 var Router = function(routes, options) {
     var opts = options || {};
@@ -12,6 +13,7 @@ var Router = function(routes, options) {
     this._matcher = matcher(this._rst);
     this._debug = opts.debug;
     this.maxRefFollow = opts.maxRefFollow || MAX_REF_FOLLOW;
+    this.maxPaths = opts.maxPaths || MAX_PATHS;
 };
 
 Router.createClass = function(routes) {

--- a/src/errors/MaxPathsExceededError.js
+++ b/src/errors/MaxPathsExceededError.js
@@ -1,0 +1,11 @@
+var MESSAGE = "Maximum number of paths exceeded.";
+
+var MaxPathsExceededError = function MaxPathsExceededError(message) {
+    this.message = message === undefined ? MESSAGE : message;
+    this.stack = (new Error()).stack;
+};
+
+MaxPathsExceededError.prototype = new Error();
+MaxPathsExceededError.prototype.throwToNext = true;
+
+module.exports = MaxPathsExceededError;

--- a/src/router/call.js
+++ b/src/router/call.js
@@ -6,6 +6,9 @@ var CallNotFoundError = require('./../errors/CallNotFoundError');
 var materialize = require('../run/materialize');
 var pathUtils = require('falcor-path-utils');
 var collapse = pathUtils.collapse;
+var Observable = require('rx').Observable;
+var MaxPathsExceededError = require('../errors/MaxPathsExceededError');
+var getPathsCount = require('./getPathsCount');
 
 /**
  * Performs the call mutation.  If a call is unhandled, IE throws error, then
@@ -13,54 +16,65 @@ var collapse = pathUtils.collapse;
  */
 module.exports = function routerCall(callPath, args,
                                      refPathsArg, thisPathsArg) {
-    var refPaths = normalizePathSets(refPathsArg || []);
-    var thisPaths = normalizePathSets(thisPathsArg || []);
-
-    var jsongCache = {};
     var router = this;
-    var action = runCallAction(router, callPath, args,
-                               refPaths, thisPaths, jsongCache);
-    var callPaths = [callPath];
-    return recurseMatchAndExecute(router._matcher, action, callPaths, call,
-                                  router, jsongCache).
 
-        // Take that
-        map(function(jsongResult) {
-            var reportedPaths = jsongResult.reportedPaths;
-            var jsongEnv = {
-                jsonGraph: jsongResult.jsonGraph
-            };
+    return Observable.defer(function() {
 
-            // Call must report the paths that have been produced.
-            if (reportedPaths.length) {
-                // Collapse the reported paths as they may be inefficient
-                // to send across the wire.
-                jsongEnv.paths = collapse(reportedPaths);
-            }
-            else {
-                jsongEnv.paths = [];
-                jsongEnv.jsonGraph = {};
-            }
+        var refPaths = normalizePathSets(refPathsArg || []);
+        var thisPaths = normalizePathSets(thisPathsArg || []);
+        var jsongCache = {};
+        var action = runCallAction(router, callPath, args,
+                                   refPaths, thisPaths, jsongCache);
+        var callPaths = [callPath];
 
-            // add the invalidated paths to the jsonGraph Envelope
-            var invalidated = jsongResult.invalidated;
-            if (invalidated && invalidated.length) {
-                jsongEnv.invalidated = invalidated;
-            }
+        if (getPathsCount(refPaths) + 
+            getPathsCount(thisPaths) + 
+            getPathsCount(callPaths) > 
+            router.maxPaths) {
+            throw new MaxPathsExceededError();
+        }
 
-            // Calls are currently materialized.
-            materialize(router, reportedPaths, jsongEnv);
-            return jsongEnv;
-        }).
+        return recurseMatchAndExecute(router._matcher, action, callPaths, call,
+                                      router, jsongCache).
 
-        // For us to be able to chain call requests then the error that is
-        // caught has to be a 'function does not exist.' error.  From that we
-        // will try the next dataSource in the line.
-        catch(function catchException(e) {
-            if (e instanceof CallNotFoundError && router._unhandled) {
-                return router._unhandled.
-                    call(callPath, args, refPaths, thisPaths);
-            }
-            throw e;
-        });
+            // Take that
+            map(function(jsongResult) {
+                var reportedPaths = jsongResult.reportedPaths;
+                var jsongEnv = {
+                    jsonGraph: jsongResult.jsonGraph
+                };
+
+                // Call must report the paths that have been produced.
+                if (reportedPaths.length) {
+                    // Collapse the reported paths as they may be inefficient
+                    // to send across the wire.
+                    jsongEnv.paths = collapse(reportedPaths);
+                }
+                else {
+                    jsongEnv.paths = [];
+                    jsongEnv.jsonGraph = {};
+                }
+
+                // add the invalidated paths to the jsonGraph Envelope
+                var invalidated = jsongResult.invalidated;
+                if (invalidated && invalidated.length) {
+                    jsongEnv.invalidated = invalidated;
+                }
+
+                // Calls are currently materialized.
+                materialize(router, reportedPaths, jsongEnv);
+                return jsongEnv;
+            }).
+
+            // For us to be able to chain call requests then the error that is
+            // caught has to be a 'function does not exist.' error.  From that
+            // we will try the next dataSource in the line.
+            catch(function catchException(e) {
+                if (e instanceof CallNotFoundError && router._unhandled) {
+                    return router._unhandled.
+                        call(callPath, args, refPaths, thisPaths);
+                }
+                throw e;
+            });
+    });
 };

--- a/src/router/get.js
+++ b/src/router/get.js
@@ -5,55 +5,68 @@ var normalizePathSets = require('../operations/ranges/normalizePathSets');
 var materialize = require('../run/materialize');
 var Observable = require('rx').Observable;
 var mCGRI = require('./../run/mergeCacheAndGatherRefsAndInvalidations');
+var MaxPathsExceededError = require('../errors/MaxPathsExceededError');
+var getPathsCount = require('./getPathsCount');
 
 /**
  * The router get function
  */
 module.exports = function routerGet(paths) {
-    var jsongCache = {};
+
     var router = this;
-    var action = runGetAction(router, jsongCache);
-    var normPS = normalizePathSets(paths);
-    return recurseMatchAndExecute(router._matcher, action, normPS,
-                                  get, router, jsongCache).
 
-        // Turn it(jsongGraph, invalidations, missing, etc.) into a
-        // jsonGraph envelope
-        flatMap(function flatMapAfterRouterGet(details) {
-            var out = {
-                jsonGraph: details.jsonGraph
-            };
+    return Observable.defer(function() {
+
+        var jsongCache = {};
+        var action = runGetAction(router, jsongCache);
+        var normPS = normalizePathSets(paths);
+
+        if (getPathsCount(normPS) > router.maxPaths) {
+            throw new MaxPathsExceededError();
+        }
+
+        return recurseMatchAndExecute(router._matcher, action, normPS,
+                                      get, router, jsongCache).
+
+            // Turn it(jsongGraph, invalidations, missing, etc.) into a
+            // jsonGraph envelope
+            flatMap(function flatMapAfterRouterGet(details) {
+                var out = {
+                    jsonGraph: details.jsonGraph
+                };
 
 
-            // If the unhandledPaths are present then we need to
-            // call the backup method for generating materialized.
-            if (details.unhandledPaths.length && router._unhandled) {
-                var unhandledPaths = details.unhandledPaths;
+                // If the unhandledPaths are present then we need to
+                // call the backup method for generating materialized.
+                if (details.unhandledPaths.length && router._unhandled) {
+                    var unhandledPaths = details.unhandledPaths;
 
-                // The 3rd argument is the beginning of the actions arguments,
-                // which for get is the same as the unhandledPaths.
-                return router._unhandled.
-                    get(unhandledPaths).
+                    // The 3rd argument is the beginning of the actions
+                    // arguments, which for get is the same as the 
+                    // unhandledPaths.
+                    return router._unhandled.
+                        get(unhandledPaths).
 
-                    // Merge the solution back into the overall message.
-                    map(function(jsonGraphFragment) {
-                        mCGRI(out.jsonGraph, [{
-                            jsonGraph: jsonGraphFragment.jsonGraph,
-                            paths: unhandledPaths
-                        }]);
-                        return out;
-                    }).
-                    defaultIfEmpty(out);
-            }
+                        // Merge the solution back into the overall message.
+                        map(function(jsonGraphFragment) {
+                            mCGRI(out.jsonGraph, [{
+                                jsonGraph: jsonGraphFragment.jsonGraph,
+                                paths: unhandledPaths
+                            }]);
+                            return out;
+                        }).
+                        defaultIfEmpty(out);
+                }
 
-            return Observable.return(out);
-        }).
+                return Observable.return(out);
+            }).
 
-        // We will continue to materialize over the whole jsonGraph message.
-        // This makes sense if you think about pathValues and an API that if
-        // ask for a range of 10 and only 8 were returned, it would not
-        // materialize for you, instead, allow the router to do that.
-        map(function(jsonGraphEnvelope) {
-            return materialize(router, normPS, jsonGraphEnvelope);
-        });
+            // We will continue to materialize over the whole jsonGraph message.
+            // This makes sense if you think about pathValues and an API that if
+            // ask for a range of 10 and only 8 were returned, it would not
+            // materialize for you, instead, allow the router to do that.
+            map(function(jsonGraphEnvelope) {
+                return materialize(router, normPS, jsonGraphEnvelope);
+            });
+    });
 };

--- a/src/router/getPathsCount.js
+++ b/src/router/getPathsCount.js
@@ -1,0 +1,9 @@
+var falcorPathUtils = require('falcor-path-utils');
+
+function getPathsCount(pathSets) {
+    return pathSets.reduce(function(numPaths, pathSet) {
+        return numPaths + falcorPathUtils.pathCount(pathSet);
+    }, 0);
+}
+
+module.exports = getPathsCount;

--- a/src/router/set.js
+++ b/src/router/set.js
@@ -13,131 +13,144 @@ var normalizePathSets = require('../operations/ranges/normalizePathSets');
 var pathUtils = require('falcor-path-utils');
 var collapse = pathUtils.collapse;
 var mCGRI = require('./../run/mergeCacheAndGatherRefsAndInvalidations');
+var MaxPathsExceededError = require('../errors/MaxPathsExceededError');
+var getPathsCount = require('./getPathsCount');
 
 /**
  * @returns {Observable.<JSONGraph>}
  * @private
  */
 module.exports = function routerSet(jsonGraph) {
-    var jsongCache = {};
+
     var router = this;
-    var action = runSetAction(router, jsonGraph, jsongCache);
-    jsonGraph.paths = normalizePathSets(jsonGraph.paths);
-    return recurseMatchAndExecute(router._matcher, action, jsonGraph.paths,
-                                  set, router, jsongCache).
 
-        // Takes the jsonGraphEnvelope and extra details that comes out of the
-        // recursive matching algorithm and either attempts the fallback
-        // options or returns the built jsonGraph.
-        flatMap(function(details) {
-            var out = {
-                jsonGraph: details.jsonGraph
-            };
+    return Observable.defer(function() {
+        var jsongCache = {};
+        var action = runSetAction(router, jsonGraph, jsongCache);
+        jsonGraph.paths = normalizePathSets(jsonGraph.paths);
 
-            // If there is an unhandler then we should call that method and
-            // provide the subset of jsonGraph that represents the missing
-            // routes.
-            if (details.unhandledPaths.length && router._unhandled) {
-                var unhandledPaths = details.unhandledPaths;
-                var jsonGraphFragment = {};
+        if (getPathsCount(jsonGraph.paths) > router.maxPaths) {
+            throw new MaxPathsExceededError();
+        }
 
-                // PERFORMANCE: We know this is a potential performance downfall
-                // PERFORMANCE: but we want to see if its even a corner case.
-                // PERFORMANCE: Most likely this will not be hit, but if it does
-                // PERFORMANCE: then we can take care of it
-                // Set is interesting.  This is what has to happen.
-                // 1.  incoming paths are spread so that each one is simple.
-                // 2.  incoming path, one at a time, are optimized by the
-                //     incoming jsonGraph.
-                // 3.  test intersection against incoming optimized path and
-                //     unhandledPathSet
-                // 4.  If 3 is true, build the jsonGraphFragment by using a
-                //     pathValue of optimizedPath and vale from un-optimized
-                //     path and original jsonGraphEnvelope.
-                var jsonGraphEnvelope = {jsonGraph: jsonGraphFragment};
-                var unhandledPathsTree = unhandledPaths.
-                    reduce(function(acc, path) {
-                        pathValueMerge(acc, {path: path, value: null});
-                        return acc;
-                    }, {});
+        return recurseMatchAndExecute(router._matcher, action, jsonGraph.paths,
+                                      set, router, jsongCache).
 
-                // 1. Spread
-                var pathIntersection = spreadPaths(jsonGraph.paths).
+            // Takes the jsonGraphEnvelope and extra details that comes out
+            // of the recursive matching algorithm and either attempts the 
+            // fallback options or returns the built jsonGraph.
+            flatMap(function(details) {
+                var out = {
+                    jsonGraph: details.jsonGraph
+                };
 
-                    // 2.1 Optimize.  We know its one at a time therefore we
-                    // just pluck [0] out.
-                    map(function(path) {
-                        return [
-                            // full path
-                            path,
+                // If there is an unhandler then we should call that method and
+                // provide the subset of jsonGraph that represents the missing
+                // routes.
+                if (details.unhandledPaths.length && router._unhandled) {
+                    var unhandledPaths = details.unhandledPaths;
+                    var jsonGraphFragment = {};
 
-                            // optimized path
-                            optimizePathSets(details.jsonGraph, [path],
-                                                router.maxRefFollow)[0]]
-                    }).
-
-                    // 2.2 Remove all the optimized paths that were found in
-                    // the cache.
-                    filter(function(x) { return x[1]; }).
-
-                    // 3.1 test intersection.
-                    map(function(pathAndOPath) {
-                        var oPath = pathAndOPath[1];
-                        var hasIntersection = hasIntersectionWithTree(
-                            oPath, unhandledPathsTree);
-
-                        // Creates the pathValue if there are a path
-                        // intersection
-                        if (hasIntersection) {
-                            var value =
-                                getValue(jsonGraph.jsonGraph, pathAndOPath[0]);
-
-                            return {
-                                path: oPath,
-                                value: value
-                            };
-                        }
-
-                        return null;
-                    }).
-
-                    // 3.2 strip out nulls (the non-intersection paths).
-                    filter(function(x) { return x !== null; });
-
-                    // 4. build the optimized JSONGraph envelope.
-                    pathIntersection.
-                        reduce(function(acc, pathValue) {
-                            pathValueMerge(acc, pathValue);
+                    // PERFORMANCE: 
+                    //   We know this is a potential performance downfall
+                    //   but we want to see if its even a corner case.
+                    //   Most likely this will not be hit, but if it does
+                    //   then we can take care of it
+                    // Set is interesting.  This is what has to happen.
+                    // 1. incoming paths are spread so that each one is simple.
+                    // 2. incoming path, one at a time, are optimized by the
+                    //    incoming jsonGraph.
+                    // 3. test intersection against incoming optimized path and
+                    //    unhandledPathSet
+                    // 4. If 3 is true, build the jsonGraphFragment by using a
+                    //    pathValue of optimizedPath and vale from un-optimized
+                    //    path and original jsonGraphEnvelope.
+                    var jsonGraphEnvelope = {jsonGraph: jsonGraphFragment};
+                    var unhandledPathsTree = unhandledPaths.
+                        reduce(function(acc, path) {
+                            pathValueMerge(acc, {path: path, value: null});
                             return acc;
-                        }, jsonGraphFragment);
+                        }, {});
 
-                jsonGraphEnvelope.paths = collapse(
-                    pathIntersection.map(function(pV) {
-                        return pV.path;
-                    }));
+                    // 1. Spread
+                    var pathIntersection = spreadPaths(jsonGraph.paths).
 
-                return router._unhandled.
-                    set(jsonGraphEnvelope).
+                        // 2.1 Optimize.  We know its one at a time therefore we
+                        // just pluck [0] out.
+                        map(function(path) {
+                            return [
+                                // full path
+                                path,
 
-                    // Merge the solution back into the overall message.
-                    map(function(unhandledJsonGraphEnv) {
-                        mCGRI(out.jsonGraph, [{
-                            jsonGraph: unhandledJsonGraphEnv.jsonGraph,
-                            paths: unhandledPaths
-                        }]);
-                        return out;
-                    }).
-                    defaultIfEmpty(out);
-            }
+                                // optimized path
+                                optimizePathSets(details.jsonGraph, [path],
+                                                    router.maxRefFollow)[0]]
+                        }).
 
-            return Observable.return(out);
-        }).
+                        // 2.2 Remove all the optimized paths that were found in
+                        // the cache.
+                        filter(function(x) { return x[1]; }).
 
-        // We will continue to materialize over the whole jsonGraph message.
-        // This makes sense if you think about pathValues and an API that
-        // if ask for a range of 10 and only 8 were returned, it would not
-        // materialize for you, instead, allow the router to do that.
-        map(function(jsonGraphEnvelope) {
-            return materialize(router, jsonGraph.paths, jsonGraphEnvelope);
-        });
+                        // 3.1 test intersection.
+                        map(function(pathAndOPath) {
+                            var oPath = pathAndOPath[1];
+                            var hasIntersection = hasIntersectionWithTree(
+                                oPath, unhandledPathsTree);
+
+                            // Creates the pathValue if there are a path
+                            // intersection
+                            if (hasIntersection) {
+                                var value =
+                                    getValue(jsonGraph.jsonGraph, 
+                                        pathAndOPath[0]);
+
+                                return {
+                                    path: oPath,
+                                    value: value
+                                };
+                            }
+
+                            return null;
+                        }).
+
+                        // 3.2 strip out nulls (the non-intersection paths).
+                        filter(function(x) { return x !== null; });
+
+                        // 4. build the optimized JSONGraph envelope.
+                        pathIntersection.
+                            reduce(function(acc, pathValue) {
+                                pathValueMerge(acc, pathValue);
+                                return acc;
+                            }, jsonGraphFragment);
+
+                    jsonGraphEnvelope.paths = collapse(
+                        pathIntersection.map(function(pV) {
+                            return pV.path;
+                        }));
+
+                    return router._unhandled.
+                        set(jsonGraphEnvelope).
+
+                        // Merge the solution back into the overall message.
+                        map(function(unhandledJsonGraphEnv) {
+                            mCGRI(out.jsonGraph, [{
+                                jsonGraph: unhandledJsonGraphEnv.jsonGraph,
+                                paths: unhandledPaths
+                            }]);
+                            return out;
+                        }).
+                        defaultIfEmpty(out);
+                }
+
+                return Observable.return(out);
+            }).
+
+            // We will continue to materialize over the whole jsonGraph message.
+            // This makes sense if you think about pathValues and an API that
+            // if ask for a range of 10 and only 8 were returned, it would not
+            // materialize for you, instead, allow the router to do that.
+            map(function(jsonGraphEnvelope) {
+                return materialize(router, jsonGraph.paths, jsonGraphEnvelope);
+            });
+    });
 };

--- a/test/unit/core/index.js
+++ b/test/unit/core/index.js
@@ -7,4 +7,5 @@ describe('Core', function() {
     require('./set.spec');
     require('./get.spec');
     require('./multi-indexer.spec');
+    require('./max-paths.spec');
 });

--- a/test/unit/core/max-paths.spec.js
+++ b/test/unit/core/max-paths.spec.js
@@ -1,0 +1,190 @@
+var chai = require('chai');
+var expect = chai.expect;
+var Router = require('../../../src/Router');
+var MaxPathsExceededError = require('../../../src/errors/MaxPathsExceededError');
+var pathCount = require('falcor-path-utils').pathCount;
+
+describe('MaxPaths', function() {
+
+    it('should fail if number of get paths is greater than maxPaths.', function(done) {
+
+        var r = new Router([]);
+
+        r.get([["lomo", {length: 9001}, "name"]]).
+        subscribe({ 
+            onNext: function(x) {},
+            onError: function(e) { 
+                expect(e).to.be.an.instanceof(MaxPathsExceededError);
+                done();
+            },
+            onCompleted: function() {}
+        });
+
+    });
+
+    it('should fail if number of set paths is greater than maxPaths.', function(done) {
+
+        var r = new Router([]);
+
+        r.set({
+            jsonGraph: {},
+            paths: [["lomo", {length: 9001}, "name"]]
+        }).
+        subscribe({ 
+            onNext: function(x) {},
+            onError: function(e) { 
+                expect(e).to.be.an.instanceof(MaxPathsExceededError);
+                done();
+            },
+            onCompleted: function() {}
+        });
+    });
+
+    it('should fail if number of call paths is greater than maxPaths.', function(done) {
+
+        var r = new Router([]);
+
+        r.call(["lomo", {length: 9001}, "name"], [], [], []).
+            subscribe({ 
+                onNext: function(x) {},
+                onError: function(e) { 
+                    expect(e).to.be.an.instanceof(MaxPathsExceededError);
+                    done();
+                },
+                onCompleted: function() {}
+            });
+    });
+
+    it('should fail number of refPaths is greater than maxPaths.', function(done) {
+
+        var r = new Router([]);
+
+        r.call(["lomo", 0, "name"], [], [[{ length: 9001 }]], []).
+            subscribe({ 
+                onNext: function(x) {},
+                onError: function(e) { 
+                    expect(e).to.be.an.instanceof(MaxPathsExceededError);
+                    done();
+                },
+                onCompleted: function() {}
+            });
+    });
+
+    it('should fail number of thisPaths is greater than maxPaths.', function(done) {
+
+        var r = new Router([]);
+
+        r.call(["lomo", 0, "name"], [], [], [[{ length: 9001 }]]).
+            subscribe({ 
+                onNext: function(x) {},
+                onError: function(e) { 
+                    expect(e).to.be.an.instanceof(MaxPathsExceededError);
+                    done();
+                },
+                onCompleted: function() {}
+            });
+    });
+
+    it('should fail if number of thisPaths + refPaths + callPaths is greater than maxPaths.', function(done) {
+
+        var r = new Router([]);
+
+        r.call(["lomo", { length: 3001 }, "name"], [], [[{ length: 3000 }]], [[{ length: 3000 }]]).
+            subscribe({ 
+                onNext: function(x) {},
+                onError: function(e) { 
+                    expect(e).to.be.an.instanceof(MaxPathsExceededError);
+                    done();
+                },
+                onCompleted: function() {}
+            });
+    });
+
+    it('should rethrow MaxPathsExceededError on get.', function(done) {
+
+        var r = new Router([{
+            route: "titlesById[{integers:titleIds}].name",
+            get: function(pathSet) {
+                if (pathSet[1].length > 20) {
+                    throw new MaxPathsExceededError();
+                }
+                return [];
+            }
+        }]);
+
+        r.get([["titlesById", {length: 21}, "name"]]).
+            subscribe({ 
+                onNext: function(x) {},
+                onError: function(e) { 
+                    expect(e).to.be.an.instanceof(MaxPathsExceededError);
+                    done();
+                },
+                onCompleted: function() {}
+            });
+    });
+
+    it('should rethrow MaxPathsExceededError on set.', function(done) {
+
+        var r = new Router([{
+            route: "titlesById[{integers:titleIds}].name",
+            set: function(jsonGraphArg) {
+                var ids = Object.keys(jsonGraphArg.titlesById);
+                if (ids.length > 1) {
+                    throw new MaxPathsExceededError();
+                }
+                return [];
+            }
+        }]);
+
+        r.set({
+            jsonGraph: {
+                titlesById: {
+                    0: {
+                        name: "House of Cards"
+                    },
+                    1: {
+                        name: "Daredevil"
+                    }
+                }
+            },
+            paths: [["titlesById", [0, 1], "name"]]
+        }).
+        subscribe({ 
+            onNext: function(x) {},
+            onError: function(e) {
+                expect(e).to.be.an.instanceof(MaxPathsExceededError);
+                done();
+            },
+            onCompleted: function() {}
+        });
+    });
+
+    it('should rethrow MaxPathsExceededError on call.', function(done) {
+
+        var r = new Router([{
+            route: 'genrelist[{integers:indices}].push',
+            call: function(callPath, args, refPaths) {
+                refPaths.forEach(function(pathSet) {
+                    if (pathCount(pathSet) > 200) {
+                        throw new MaxPathsExceededError("You requested too many refPaths from the new list.");
+                    }
+                });
+            }
+        }]);
+
+        r.call(["genrelist", 23, "push"], 
+            [{ $type: "ref", value: ["genrelistsById", 296] }], 
+            [[{ to: 500 }, "name"]]).
+            subscribe({ 
+                onNext: function(x) {},
+                onError: function(e) { 
+                    expect(e).to.be.an.instanceof(MaxPathsExceededError);
+                    done();
+                },
+                onCompleted: function() {}
+            });
+
+    });
+
+
+});


### PR DESCRIPTION
# Limiting the number of paths returned by the Router

Prior to version 0.4.0, the Falcor Router had a serious DOS vulnerability: requesting a large range of values could pin the CPU of the server running the Router.

Consider the following example in which the name of huge number of genrelists is requested from the Router:

```js
// falcor-router v0.3.0 and below
var Router = require('falcor-router');
var router = new Router(
  [
    {
      route: "genrelists[{integers}].name",
      get: function(pathSet) {
        // code to return the names of each of the requested genre lists
      }
    }
  ]);

// pins CPU!
router.
  get(["genrelists", {from:0, to: Number.MAX_SAFE_INTEGER}, "name"]).
  subscribe({ 
    onNext: function(jsonGraphEnvelope) { console.log(JSON.stringify(jsonGraphEnvelope)); },
    onError: function(error) { console.error(error); },
    onCompleted: function() { console.log("done"); })
```


## The `maxPaths` option

The DOS vulnerability has been mitigated in v0.4.0 by adding a `maxPaths` value to the options object accepted by the Router constructor. This value specifies the maximum number of paths which can be returned by a Falcor Router operation (either get, set, or call). The `maxPaths` value has a somewhat arbitrary default of 9000, which should provide some basic protection against a DOS.

```js
// falcor-router v0.4.0 and above
var Router = require('falcor-router');
var MaxPathsExceeded = require('falcor-router/errors/MaxPathsExceeded');
var router = new Router(
  [
    {
      route: "genrelists[{integers}].name",
      get: function(pathSet) {
        // code to return the names of each of the requested genre lists
      }
    }
  ], { maxPaths: 500 });

// prints "You asked for too many paths."
router.
  get(["genrelists", {from:0, to: Number.MAX_SAFE_INTEGER}, "name"]).
  subscribe({ 
    onNext: function(jsonGraphEnvelope) { console.log(JSON.stringify(jsonGraphEnvelope)); },
    onError: function(error) { 
      if (error instanceof MaxPathsExceeded) {
        console.error("You asked for too many paths."); 
      }
    },
    onCompleted: function() { console.log("done"); })
```

## Setting maximum path limits for individual routes

The `maxPaths` value allows you to set a global limit on the number of paths returned by a Router operation. However developers may want to set different maximums for different routes. For example you may want to allow no more than 10 titles and no more than 100 people to be retrieved in a single operation. To accomplish this, developers can test for the size of requested paths manually within a route handler and throw the `MaxPathsExceeded` error if too many paths are requested.

```js
// falcor-router v0.4.0 and above
var Router = require('falcor-router');
var MaxPathsExceeded = require('falcor-router/errors/MaxPathsExceeded');
var router = new Router(
  [
    {
      route: "genrelists[{integers}].name",
      get: function(pathSet) {
        // limit the number of requested genrelists to 200
        if (pathSet[1].length > 200) {
          throw new MaxPathsExceededError("You exceeded the maximum number of genre lists that can be requested in a single operation.");
        }
        // code to return the names of each of the requested genre lists
      }
    }
  ], { maxPaths: 500 });

// prints "You exceeded the maximum number of genre lists that can be requested in a single operation."
router.
  get(["genrelists", {from:0, to: Number.MAX_SAFE_INTEGER}, "name"]).
  subscribe({ 
    onNext: function(jsonGraphEnvelope) { console.log(JSON.stringify(jsonGraphEnvelope)); },
    onError: function(error) { 
      if (error instanceof MaxPathsExceeded) {
        console.error(error.message); 
      }
    },
    onCompleted: function() { console.log("done"); })
```
