### PR TITLE
Avoid npm no license field warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,7 @@
     "name": "Netflix",
     "url": "https://github.com/Netflix/falcor-router/authors.txt"
   },
-  "licenses": [
-    {
-      "type": "Apache License, Version 2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-    }
-  ],
+  "license": "Apache-2.0",
   "directories": {
     "test": "test"
   },
@@ -55,7 +50,6 @@
     "Netflix",
     "falcorjs"
   ],
-  "license": "ALV2",
   "bugs": {
     "url": "https://github.com/Netflix/falcor-router/issues"
   }


### PR DESCRIPTION
> Some old packages used license objects or a "licenses" property containing an array of license objects [...] Those styles are now deprecated. Instead, use SPDX expressions

https://docs.npmjs.com/files/package.json#license