### PR TITLE
If createClass is used make sure all options are set

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -20,6 +20,8 @@ Router.createClass = function(routes) {
     function C(options) {
         var opts = options || {};
         this._debug = opts.debug;
+        this.maxRefFollow = opts.maxRefFollow || MAX_REF_FOLLOW;
+        this.maxPaths = opts.maxPaths || MAX_PATHS;
     }
 
     C.prototype = new Router(routes);


### PR DESCRIPTION
I found that maxPaths and maxRefFollow are not set if you create your own class and use createClass from the router.

Simple fix for this.