### PR TITLE
Fixes a bug which causes matched routes to be ignored when the incoming paths are collapsed.

### DIFF
--- a/src/run/precedence/getExecutableMatches.js
+++ b/src/run/precedence/getExecutableMatches.js
@@ -38,6 +38,8 @@ module.exports = function getExecutableMatches(matches, pathSet) {
                     match: match
                 };
                 remainingPaths = remainingPaths.concat(stripResults[1]);
+            } else if (i < matches.length - 1) {
+                remainingPaths[remainingPaths.length] = path;
             }
         }
     }

--- a/test/unit/core/get.spec.js
+++ b/test/unit/core/get.spec.js
@@ -507,6 +507,38 @@ describe('Get', function() {
             subscribe(noOp, done, done);
     });
 
+    it('should match all specific route handlers when input paths are collapsed', function (done) {
+
+        var called = 0;
+        var router = new R([
+            { route: 'foo.name',   get: function() { return { path: ['foo', 'name'],   value: 'foo-name'}; } },
+            { route: 'bar.name',   get: function() { return { path: ['bar', 'name'],   value: 'bar-name'}; } },
+            { route: 'foo.rating', get: function() { return { path: ['foo', 'rating'], value: 'foo-rating'}; } },
+            { route: 'bar.rating', get: function() { return { path: ['bar', 'rating'], value: 'bar-rating'}; } }
+        ]);
+
+        router.
+            get([[['foo', 'bar'], ['name', 'rating']]]).
+            doAction(function(x) {
+                expect(x).to.deep.equals({
+                    jsonGraph: {
+                        'foo': {
+                            name: 'foo-name',
+                            rating: 'foo-rating'
+                        },
+                        'bar': {
+                            name: 'bar-name',
+                            rating: 'bar-rating'
+                        }
+                    }
+                });
+                called++;
+            }, noOp, function() {
+                expect(called).to.equals(1);
+            }).
+            subscribe(noOp, done, done);
+    });
+
     function getPrecedenceRouter(onTitle, onRating) {
         return new R([{
             route: 'videos[{integers:ids}].title',


### PR DESCRIPTION
This PR fixes a bug where the router would not run matched route handlers that differ in any branch key positions when the incoming paths are collapsed.

```es6
var router = new Router([
  { route: 'foo.name',   get: function() { return { path: ['foo', 'name'],   value: 'foo-name'}; } },
  { route: 'bar.name',   get: function() { return { path: ['bar', 'name'],   value: 'bar-name'}; } },
  { route: 'foo.rating', get: function() { return { path: ['foo', 'rating'], value: 'foo-rating'}; } },
  { route: 'bar.rating', get: function() { return { path: ['bar', 'rating'], value: 'bar-rating'}; } }
]);

router.
  get([[['foo', 'bar'], ['name', 'rating']]]).
  subscribe(function(x) {
    expect(x).to.deep.equals({
      jsonGraph: {
        'foo': {
          name: 'foo-name',
          rating: 'foo-rating'
        },
        'bar': {
          name: 'bar-name',
          rating: 'bar-rating'
        }
      }
    });
    /*
      AssertionError: expected { Object (jsonGraph) } to deeply equal { Object (jsonGraph) }
      + expected - actual

      {
       "jsonGraph": {
         "bar": {
      -    "name": {
      -    "$type": "atom"
      -    }
      +    "name": "bar-name"
         "rating": "bar-rating"
         }
         "foo": {
      -    "name": {
      -    "$type": "atom"
      -    }
      +    "name": "foo-name"
         "rating": "foo-rating"
         }
       }
      }
    */
  });
```