### PR TITLE
Fix error caused by undefined pathValue.value

### DIFF
--- a/src/cache/pathValueMerge.js
+++ b/src/cache/pathValueMerge.js
@@ -20,7 +20,7 @@ module.exports = function pathValueMerge(cache, pathValue) {
 
     // References.  Needed for evaluationg suffixes in all three types, get,
     // call and set.
-    else if ((pathValue.value !== null) && (pathValue.value.$type === $ref)) {
+    else if ((pathValue.value !== null && pathValue.value !== undefined) && (pathValue.value.$type === $ref)) {
         refs.push({
             path: pathValue.path,
             value: pathValue.value.value


### PR DESCRIPTION
I'm not sure under what circumstances value is `undefined`.

If `pathValue.value` being `undefined` means I'm doing something wrong elsewhere, I suppose an error could be thrown here, to help troubleshoot the misstep. I need to look deeper into where the `undefined` is coming from.