### PR TITLE
Fix usage of full Rx object in tests

### DIFF
--- a/src/RouterRx.js
+++ b/src/RouterRx.js
@@ -8,10 +8,20 @@ var RouterRx = {
 require('rxjs/add/observable/defer');
 require('rxjs/add/observable/of');
 require('rxjs/add/observable/from');
+require('rxjs/add/observable/empty');
+require('rxjs/add/observable/throw');
 
 require('rxjs/add/operator/mergeMap');
 require('rxjs/add/operator/do');
 require('rxjs/add/operator/defaultIfEmpty');
 require('rxjs/add/operator/materialize');
+require('rxjs/add/operator/expand');
+require('rxjs/add/operator/reduce');
+require('rxjs/add/operator/map');
+require('rxjs/add/operator/filter');
+require('rxjs/add/operator/catch');
+require('rxjs/add/operator/toArray');
+require('rxjs/add/operator/concat');
+require('rxjs/add/operator/delay');
 
 module.exports = RouterRx;

--- a/test/data/GenrelistRoutes.js
+++ b/test/data/GenrelistRoutes.js
@@ -1,5 +1,4 @@
-var Rx = require('rxjs');
-var Observable = Rx.Observable;
+var Observable = require('rxjs/Observable').Observable;
 var TestRunner = require('./../TestRunner');
 var falcor = require('falcor');
 var $ref = falcor.Model.ref;

--- a/test/data/VideoRoutes.js
+++ b/test/data/VideoRoutes.js
@@ -1,5 +1,4 @@
-var Rx = require('rxjs');
-var Observable = Rx.Observable;
+var Observable = require('rxjs/Observable').Observable;
 var R = require('../../src/Router');
 var TestRunner = require('./../TestRunner');
 var Model = require('falcor').Model;

--- a/test/unit/core/call.spec.js
+++ b/test/unit/core/call.spec.js
@@ -1,4 +1,4 @@
-var Observable = require('rxjs').Observable;
+var Observable = require('rxjs/Observable').Observable;
 var R = require('../../../src/Router');
 var noOp = function() {};
 var chai = require('chai');

--- a/test/unit/core/get.spec.js
+++ b/test/unit/core/get.spec.js
@@ -7,7 +7,7 @@ var expect = chai.expect;
 var falcor = require('falcor');
 var $ref = falcor.Model.ref;
 var $atom = falcor.Model.atom;
-var Observable = require('rxjs').Observable;
+var Observable = require('rxjs/Observable').Observable;
 var sinon = require('sinon');
 
 describe('Get', function() {

--- a/test/unit/functional/collapse-and-batch.spec.js
+++ b/test/unit/functional/collapse-and-batch.spec.js
@@ -6,7 +6,7 @@ var expect = chai.expect;
 var falcor = require('falcor');
 var $ref = falcor.Model.ref;
 var $atom = falcor.Model.atom;
-var Observable = require('rxjs').Observable;
+var Observable = require('rxjs/Observable').Observable;
 var Promise = require('promise');
 
 describe('Collapse and Batch', function() {

--- a/test/unit/functional/materialized.spec.js
+++ b/test/unit/functional/materialized.spec.js
@@ -6,7 +6,7 @@ var chai = require('chai');
 var expect = chai.expect;
 var falcor = require('falcor');
 var $ref = falcor.Model.ref;
-var Observable = require('rxjs').Observable;
+var Observable = require('rxjs/Observable').Observable;
 
 describe('Materialized Paths.', function() {
     function partialRouter() {

--- a/test/unit/functional/precedence.spec.js
+++ b/test/unit/functional/precedence.spec.js
@@ -2,7 +2,7 @@ var R = require('../../../src/Router');
 var noOp = function() {};
 var chai = require('chai');
 var expect = chai.expect;
-var Observable = require('rxjs').Observable;
+var Observable = require('rxjs/Observable').Observable;
 var sinon = require('sinon');
 
 describe('Precedence Matching', function() {

--- a/test/unit/functional/return-types.spec.js
+++ b/test/unit/functional/return-types.spec.js
@@ -2,7 +2,7 @@ var R = require('../../../src/Router');
 var noOp = function() {};
 var chai = require('chai');
 var expect = chai.expect;
-var Observable = require('rxjs').Observable;
+var Observable = require('rxjs/Observable').Observable;
 var Promise = require('promise');
 
 describe('return-types', function() {

--- a/test/unit/functional/unhandled.call.spec.js
+++ b/test/unit/functional/unhandled.call.spec.js
@@ -3,7 +3,7 @@ var noOp = function() {};
 var chai = require('chai');
 var expect = chai.expect;
 var sinon = require('sinon');
-var Observable = require('rxjs').Observable;
+var Observable = require('rxjs/Observable').Observable;
 
 describe('#call', function() {
     it('should ensure a missing function gets chained.', function(done) {

--- a/test/unit/functional/unhandled.get.spec.js
+++ b/test/unit/functional/unhandled.get.spec.js
@@ -4,7 +4,7 @@ var chai = require('chai');
 var expect = chai.expect;
 var sinon = require('sinon');
 var pathValueMerge = require('./../../../src/cache/pathValueMerge');
-var Observable = require('rxjs').Observable;
+var Observable = require('rxjs/Observable').Observable;
 var $atom = require('./../../../src/support/types').$atom;
 
 describe('#get', function() {

--- a/test/unit/functional/unhandled.set.spec.js
+++ b/test/unit/functional/unhandled.set.spec.js
@@ -4,7 +4,7 @@ var chai = require('chai');
 var expect = chai.expect;
 var sinon = require('sinon');
 var pathValueMerge = require('./../../../src/cache/pathValueMerge');
-var Observable = require('rxjs').Observable;
+var Observable = require('rxjs/Observable').Observable;
 var $atom = require('./../../../src/support/types').$atom;
 var $ref = require('./../../../src/support/types').$ref;
 

--- a/test/unit/internal/rxNewToRxNewAndOld.spec.js
+++ b/test/unit/internal/rxNewToRxNewAndOld.spec.js
@@ -1,4 +1,5 @@
-var Observable = require('rxjs/Rx').Observable;
+// var Observable = require('rxjs/Rx').Observable;
+var Observable = require('rxjs/Observable').Observable;
 var rxNewToRxNewAndOld =
     require('../../../../src/run/conversion/rxNewToRxNewAndOld');
 var chai = require('chai');


### PR DESCRIPTION
Fixes #197 

Tests are currently using the full Rx object which is not available when using the router in production. This PR ensures all tests use a plain `Observable` (`require('rxjs/Observable').Observable`).

Additional operators and behaviours are added to make tests pass.