### PR TITLE
fix(symbol-observable): dependency added appropriately

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "falcor-path-syntax": "0.2.4",
     "falcor-path-utils": "~0.5.0",
-    "rxjs": "5.0.3"
+    "rxjs": "5.0.3",
+    "symbol-observable": "^1.0.4"
   },
   "devDependencies": {
     "chai": "^2.3.0",
@@ -33,7 +34,6 @@
     "lodash": "^3.8.0",
     "promise": "^7.0.1",
     "sinon": "^1.15.4",
-    "symbol-observable": "^1.0.4",
     "through2": "~0.6.3"
   },
   "scripts": {


### PR DESCRIPTION
I like to have PRs even for simple fixes like this, because commit and PR trails are good.

- this just moves the `symbol-observable` dependency from a devDependency to a regular dependency.

